### PR TITLE
Update to 2.6 for os x mavericks compatibility, update download URL

### DIFF
--- a/install.js
+++ b/install.js
@@ -11,24 +11,28 @@ var mkdirp = require('mkdirp')
 var path = require('path')
 var rimraf = require('rimraf').sync
 var url = require('url')
+var util = require('util')
 
 var libPath = path.join(__dirname, 'lib', 'chromedriver')
-var downloadUrl = 'http://chromedriver.googlecode.com/files/chromedriver_'
+var downloadUrl = 'http://chromedriver.storage.googleapis.com/%s/chromedriver_%s.zip'
+var platform = process.platform
 
-if (process.platform === 'linux' && process.arch === 'x64') {
-  downloadUrl += 'linux64'
-} else if (process.platform === 'linux') {
-  downloadUrl += 'linux32'
-} else if (process.platform === 'darwin') {
-  downloadUrl += 'mac32'
-} else if (process.platform === 'win32') {
-  downloadUrl += 'win32'
+if (platform === 'linux') {
+  if (process.arch === 'x64') {
+    platform += '64'
+  } else {
+    platform += '32'
+  }
+} else if (platform === 'darwin') {
+  platform = 'mac32'
+} else if (platform === 'win32') {
+  helper.version = '2.4'
 } else {
   console.log('Unexpected platform or architecture:', process.platform, process.arch)
   process.exit(1)
 }
 
-downloadUrl += '_' + helper.version + '.zip';
+downloadUrl = util.format(downloadUrl, helper.version, platform);
 
 var fileName = downloadUrl.split('/').pop()
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,6 +1,6 @@
 var path = require('path');
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.3';
+exports.version = '2.6';
 exports.start = function() {
   exports.defaultInstance = require('child_process').execFile(exports.path);
   return exports.defaultInstance;


### PR DESCRIPTION
Not sure you're ready to update this all the way to 2.6, since there's not a version out for windows and it's fairly new.  However, it contains a fix so it's actually usable on the new version of os x.
