### PR TITLE
Fixed installation of the package for Node v0.8 and similar.

### DIFF
--- a/install.js
+++ b/install.js
@@ -190,9 +190,12 @@ function copyIntoPlace(tmpPath, targetPath) {
 
     var targetFile = path.join(targetPath, name);
     var writer = fs.createWriteStream(targetFile);
-    writer.on("finish", function() {
+
+    var listener = function() {
       deferred.resolve(true);
-    });
+    }
+    writer.on("close", listener);  // for node v0.8
+    writer.on("finish", listener);
 
     reader.pipe(writer);
     return deferred.promise;


### PR DESCRIPTION
In recent Node versions there is a 'finish' event on Writable stream ( http://nodejs.org/api/stream.html#stream_event_finish ), but in older versions it was called 'close' ( http://nodejs.org/docs/v0.8.6/api/stream.html#stream_event_close_1 ).

Without listening on 'close', promise chain aborts on 'copyIntoPlace' without any notice, therefore following functions, such as 'fixFilePermissions', are never executed.

Fixes #9.
