### PR TITLE
configurable chromedriver mirror URL

### DIFF
--- a/install.js
+++ b/install.js
@@ -14,7 +14,7 @@ var url = require('url')
 var util = require('util')
 
 var libPath = path.join(__dirname, 'lib', 'chromedriver')
-var downloadUrl = 'http://chromedriver.storage.googleapis.com/%s/chromedriver_%s.zip'
+var downloadUrl = (process.env.CHROMEDRIVER_CDNURL || 'http://chromedriver.storage.googleapis.com') + '/%s/chromedriver_%s.zip'
 var platform = process.platform
 
 if (platform === 'linux') {


### PR DESCRIPTION
Provide a way to define a mirror url for the chromedriver download. This enables users in a internet-restricted environment (flaky internet connections or corporate proxies) to run a locally hosted mirror for chromedriver.

This implementation allows user to define an environment variable CHROMEDRIVER_CDNURL to override the default hostname used for downloading the chromedriver. This is similar to phantomjs' implementation (https://github.com/Medium/phantomjs/blob/master/install.js).
