### PR TITLE
Support configure chromedriver cdn url via npm config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ The package has been set up to fetch and run ChromeDriver for MacOS (darwin),
 Linux based platforms (as identified by nodejs), and Windows.  If you
 spot any platform weirdnesses, let us know or send a patch.
 
+### Custom binaries url
+
+To use a mirror of the ChromeDriver binaries use npm config property `chromedriver_cdnurl`.
+Default is `http://chromedriver.storage.googleapis.com`.
+
+```shell
+npm install chromedriver --chromedriver_cdnurl=http://npm.taobao.org/mirrors/chromedriver
+```
+
+Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
+
+```
+chromedriver_cdnurl=http://npm.taobao.org/mirrors/chromedriver
+```
+
+Another option is to use PATH variable `CHROMEDRIVER_CDNURL`.
+
+```shell
+CHROMEDRIVER_CDNURL=http://npm.taobao.org/mirrors/chromedriver npm install chromedriver
+```
+
 Running
 -------
 

--- a/install.js
+++ b/install.js
@@ -14,7 +14,10 @@ var url = require('url')
 var util = require('util')
 
 var libPath = path.join(__dirname, 'lib', 'chromedriver')
-var downloadUrl = (process.env.CHROMEDRIVER_CDNURL || 'http://chromedriver.storage.googleapis.com') + '/%s/chromedriver_%s.zip'
+var cdnUrl = process.env.npm_config_chromedriver_cdnurl || process.env.CHROMEDRIVER_CDNURL || 'http://chromedriver.storage.googleapis.com'
+// adapt http://chromedriver.storage.googleapis.com/
+cdnUrl = cdnUrl.replace(/\/+$/, '')
+var downloadUrl = cdnUrl + '/%s/chromedriver_%s.zip'
 var platform = process.platform
 
 if (platform === 'linux') {


### PR DESCRIPTION
```shell
npm install phantomjs --chromedriver_cdnurl=http://npm.taobao.org/mirrors/chromedriver
```