### PR TITLE
Enabled chromedriver.start(arguments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,19 @@ childProcess.execFile(binPath, childArgs, function(err, stdout, stderr) {
 
 You can also use the start and stop methods:
 
-
 ```javascript
 var chromedriver = require('chromedriver');
 
-chromedriver.start();
-//run your tests
+args = {
+	// optional arguments
+};
+chromedriver.start(args);
+// run your tests
 chromedriver.stop();
 
 ```
+Note: if your tests are ran asynchronously, chromedriver.stop() will have to be
+executed as a callback at the end of your tests
 
 Versioning
 ----------

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,8 +1,8 @@
 var path = require('path');
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
 exports.version = '2.19';
-exports.start = function() {
-  exports.defaultInstance = require('child_process').execFile(exports.path);
+exports.start = function(args) {
+  exports.defaultInstance = require('child_process').execFile(exports.path, args);
   return exports.defaultInstance;
 }
 exports.stop = function () {


### PR DESCRIPTION
Also made a note in the README cautioning against confusing asynchronous
tests for synchronous ones when using start() and stop()