### PR TITLE
follow npm strict-ssl setting

### DIFF
--- a/install.js
+++ b/install.js
@@ -118,6 +118,8 @@ function getRequestOptions(proxyUrl) {
     options = url.parse(downloadUrl)
   }
 
+  options.rejectUnauthorized = !!process.env.npm_config_strict_ssl
+
   // Use certificate authority settings from npm
   var ca = process.env.npm_config_ca
   if (!ca && process.env.npm_config_cafile) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
This makes the download of the chrome driver zip use the same setting for checking certs as npm uses.