### PR TITLE
Changing test to hopefully work on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ node_js:
   - '6'
 os:
   - linux
-script: "npm install && timeout 10 ./bin/chromedriver || test $? -eq 124"
+  - osx
+install: "npm install"
+script: "./test-driver.sh"

--- a/test-driver.sh
+++ b/test-driver.sh
@@ -1,0 +1,25 @@
+# Start ChromeDriver and make it non-blocking with ampersand
+./bin/chromedriver &
+
+# Keep track of the ChromeDrivers Process ID
+TASK_PID=$!
+
+# Wait for 10 seconds to give the ChromeDriver a chance to fail if there is an
+# issue.
+sleep 10
+
+# ps -p Checks if the process is still running. If it is it returns 0,
+# otherwise it returns 1
+ps -p $TASK_PID > /dev/null
+TASK_RUNNING=$?
+
+# Check if the process is still running by examining the exit code of ps -p
+TEST_RESULT=1
+if [ $TASK_RUNNING -eq 0 ]; then
+  # Still running so return with safe exit code
+  TEST_RESULT=0
+fi
+
+kill $TASK_PID
+
+exit $TEST_RESULT


### PR DESCRIPTION
Still need to test on Linux, but I don't see any reason for it to fail.

timeout isn't supported on OS X and I couldn't find a solution that replicated the exit code the test was relying on.