### PR TITLE
Add support for FreeBSD

### DIFF
--- a/install.js
+++ b/install.js
@@ -34,6 +34,12 @@ if (platform === 'linux') {
     console.log('Only Mac 64 bits supported.');
     process.exit(1);
   }
+} else if (platform === 'freebsd') {
+  if (process.arch === 'x64') {
+    platform = 'mac64'
+  } else {
+    platform = 'mac32'
+  }
 } else if (platform !== 'win32') {
   console.log('Unexpected platform or architecture:', process.platform, process.arch)
   process.exit(1)


### PR DESCRIPTION
I use FreeBSD 10.2, and one of my web apps failed to build during an update because chromedriver hasn't yet added support. This little addition got me back up and running and I hope it helps someone else.