### PR TITLE
Allow a file on the filesystem to be used as the source for the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ Another option is to use PATH variable `CHROMEDRIVER_CDNURL`.
 CHROMEDRIVER_CDNURL=http://npm.taobao.org/mirrors/chromedriver npm install chromedriver
 ```
 
+### Custom binaries file
+
+To get the chromedriver from the filesystem instead of a web request use the npm config property `chromedriver_filepath`.
+
+```shell
+npm install chromedriver --chromedriver_filepath=/path/to/chromedriver_mac64.zip
+```
+
+Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
+
+```
+chromedriver_filepath=/path/to/chromedriver_mac64.zip
+```
+
+Another option is to use the PATH variable `CHROMEDRIVER_FILEPATH`
+
+```shell
+CHROMEDRIVER=/path/to/chromedriver_mac64.zip
+```
+
 Running
 -------
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ chromedriver_filepath=/path/to/chromedriver_mac64.zip
 Another option is to use the PATH variable `CHROMEDRIVER_FILEPATH`
 
 ```shell
-CHROMEDRIVER=/path/to/chromedriver_mac64.zip
+CHROMEDRIVER_FILEPATH=/path/to/chromedriver_mac64.zip
 ```
 
 Running

--- a/install.js
+++ b/install.js
@@ -15,6 +15,8 @@ var util = require('util');
 
 var libPath = path.join(__dirname, 'lib', 'chromedriver');
 var cdnUrl = process.env.npm_config_chromedriver_cdnurl || process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
+var configuredfilePath = process.env.npm_config_chromedriver_filepath || process.env.CHROMEDRIVER_FILEPATH;
+
 // adapt http://chromedriver.storage.googleapis.com/
 cdnUrl = cdnUrl.replace(/\/+$/, '');
 var downloadUrl = cdnUrl + '/%s/chromedriver_%s.zip';
@@ -62,9 +64,14 @@ npmconf.load(function(err, conf) {
 
   // Start the install.
   promise = promise.then(function () {
-    console.log('Downloading', downloadUrl);
-    console.log('Saving to', downloadedFile);
-    return requestBinary(getRequestOptions(conf), downloadedFile);
+    if (configuredfilePath) {
+      console.log('Using file: ', configuredfilePath);
+      downloadedFile = configuredfilePath;
+    } else {
+      console.log('Downloading', downloadUrl);
+      console.log('Saving to', downloadedFile);
+      return requestBinary(getRequestOptions(conf), downloadedFile);
+    }
   });
 
   promise.then(function () {


### PR DESCRIPTION
In my client's environment we are not able to retrieve the chromedriver over the network. We are however able to get the chromedriver binary on the filesystem. 

This change allows the installer to take a local file as the source instead of requiring a download. 
It would be awesome if this feature became available. 