### PR TITLE
Version bump to 2.30.0, update to chromedriver 2.30

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,7 +1,7 @@
 var path = require('path');
 process.env.PATH += path.delimiter + path.join(__dirname, 'chromedriver');
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.29';
+exports.version = '2.30';
 exports.start = function(args) {
   exports.defaultInstance = require('child_process').execFile(exports.path, args);
   return exports.defaultInstance;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.29.2",
+  "version": "2.30.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
https://chromedriver.storage.googleapis.com/2.30/notes.txt

Verified in Mac OS X and Linux, installed 2.30 and protractor tests using chromedriver succeed.