### PR TITLE
.npmrc ca option does not work correctly

### DIFF
--- a/install.js
+++ b/install.js
@@ -126,6 +126,16 @@ function getRequestOptions(downloadPath) {
 
   // Use certificate authority settings from npm
   var ca = process.env.npm_config_ca;
+
+  // Parse ca string like npm does
+  if (ca && ca.match(/^".*"$/)) {
+    try {
+      ca = JSON.parse(ca.trim());
+    } catch (e) {
+      console.error('Could not parse ca string', process.env.npm_config_ca, e);
+    }
+  }
+
   if (!ca && process.env.npm_config_cafile) {
     try {
       ca = fs.readFileSync(process.env.npm_config_cafile, {encoding: 'utf8'})


### PR DESCRIPTION
Hi,

I've been trying to use the string CA option of node-chromedriver, however it doesn't work correctly. The format specified in the [npm documentation](https://docs.npmjs.com/misc/config) is ca="-----BEGIN CERTIFICATE-----\nXYZ1234.....", the current code leaves the newline and double quotes in and the certificate won't be sent correctly.

https://github.com/npm/npm/blob/2091dd1c748e54e85e904ce8da3b3975ee99117d/lib/config/core.js#L375-L381

As you can see in the npm source code above the correct way is to check if the string contains double quotes then run JSON.parse on it and then use it.

Enclosed is a pull request to fix the issue.