### PR TITLE
Use arch to determine OS architecture

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,10 +21,10 @@ var platform = process.platform;
 
 var chromedriver_version = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || helper.version;
 if (platform === 'linux') {
-  if (process.arch === 'x64') {
+  if (process.arch === 'x64' || process.arch === 'ia32') {
     platform += '64';
   } else {
-    console.log('Only Linux 64 bits supported:', process.platform, process.arch);
+    console.log('Only Linux 64 bits supported.');
     process.exit(1);
   }
 } else if (platform === 'darwin' || platform === 'freebsd') {

--- a/install.js
+++ b/install.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var arch = require('arch');
 var extractZip = require('extract-zip');
 var fs = require('fs');
 var helper = require('./lib/chromedriver');
@@ -18,24 +19,25 @@ var configuredfilePath = process.env.npm_config_chromedriver_filepath || process
 cdnUrl = cdnUrl.replace(/\/+$/, '');
 var downloadUrl = cdnUrl + '/%s/chromedriver_%s.zip';
 var platform = process.platform;
+var is64bit = arch() === 'x64';
 
 var chromedriver_version = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || helper.version;
 if (platform === 'linux') {
-  if (process.arch === 'x64' || process.arch === 'ia32') {
+  if (is64bit) {
     platform += '64';
   } else {
     console.log('Only Linux 64 bits supported.');
     process.exit(1);
   }
 } else if (platform === 'darwin' || platform === 'freebsd') {
-  if (process.arch === 'x64') {
+  if (is64bit) {
     platform = 'mac64';
   } else {
     console.log('Only Mac 64 bits supported.');
     process.exit(1);
   }
 } else if (platform !== 'win32') {
-  console.log('Unexpected platform or architecture:', process.platform, process.arch);
+  console.log('Unexpected platform or architecture:', platform, process.arch);
   process.exit(1);
 }
 

--- a/install.js
+++ b/install.js
@@ -24,7 +24,7 @@ if (platform === 'linux') {
   if (process.arch === 'x64') {
     platform += '64';
   } else {
-    console.log('Only Linux 64 bits supported.');
+    console.log('Only Linux 64 bits supported:', process.platform, process.arch);
     process.exit(1);
   }
 } else if (platform === 'darwin' || platform === 'freebsd') {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "install": "node install.js"
   },
   "dependencies": {
+    "arch": "^2.1.0",
     "del": "^3.0.0",
     "extract-zip": "^1.6.5",
     "kew": "^0.7.0",


### PR DESCRIPTION
Problem with `process.arch` is that it returns a string identifying the OS CPU architecture for which the Node.js binary was compiled.
https://nodejs.org/api/process.html#process_process_arch

There is also `os.arch()`, but unfortunately it retursn the same value as `process.arch`.
https://nodejs.org/api/os.html#os_os_arch

You can run Node.js 32-bit on a 64-bit OS.
In that situation, `process.arch` will return a misleading 'x86' (32-bit) value instead of 'x64' (64-bit).

https://github.com/feross/arch solves that problem.