### PR TITLE
Start chromedriver using spawn instead of execFile

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,10 +1,13 @@
 var path = require('path');
 process.env.PATH += path.delimiter + path.join(__dirname, 'chromedriver');
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.38';
+exports.version = '2.37';
 exports.start = function(args) {
-  exports.defaultInstance = require('child_process').execFile(exports.path, args);
-  return exports.defaultInstance;
+  var cp = require('child_process').spawn(exports.path, args);
+  cp.stdout.pipe(process.stdout);
+  cp.stderr.pipe(process.stderr);
+  exports.defaultInstance = cp;
+  return cp;
 };
 exports.stop = function () {
   if (exports.defaultInstance != null){

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,7 +1,7 @@
 var path = require('path');
 process.env.PATH += path.delimiter + path.join(__dirname, 'chromedriver');
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.37';
+exports.version = '2.38';
 exports.start = function(args) {
   var cp = require('child_process').spawn(exports.path, args);
   cp.stdout.pipe(process.stdout);


### PR DESCRIPTION
Fixes #150.

Note that this PR attaches chromedriver's stdout/stderr to the parent process's. I couldn't get it to work any other way (but that's probably because of my limited knowledge of `child_process`). (I think that's kind of nice though, the current master just throws it away).