### PR TITLE
Add chromedriver to the beginning of PATH, rather than to the end

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,5 +1,5 @@
 var path = require('path');
-process.env.PATH += path.delimiter + path.join(__dirname, 'chromedriver');
+process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
 exports.version = '2.38';
 exports.start = function(args) {


### PR DESCRIPTION
This fixes an issue where if you had a globally installed copy of chromedriver (e.g. in /usr/local/bin), projects using this npm package would inadvertently end up using the global version rather than the one specified in their project's package.json file.