### PR TITLE
Bump ChromeDriver version to 2.42

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,7 +1,7 @@
 var path = require('path');
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.41';
+exports.version = '2.42';
 exports.start = function(args) {
   var cp = require('child_process').spawn(exports.path, args);
   cp.stdout.pipe(process.stdout);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
Bump version to 2.42.
https://sites.google.com/a/chromium.org/chromedriver/downloads
https://chromedriver.storage.googleapis.com/index.html?path=2.42/

**Supports Chrome v68-70**

Changes include:
- Fixed ClickEelement in Mobile Emulation
- Fixed whitelisted IPs with IPv4
- Fixed starting ChromeDriver with whitelisted-ips flag on Mac OS
- Fixed SetTimeout to accept both pre-W3C and W3C formats
- Fixed take element screenshot
- Fixed ChromeDriver is looking for Chrome binaries in a system PATH as well
- Fixed Maximize window and Full Screen
- Implemented log-replay functionality. ( Does not work for Android and Remote Browser yet )
- Fixed some error codes were not compliant to W3C standard
- Fixed console.log with multiple arguments not handled properly
- Fixed GetElementRect should allow doubles
- Fixed touch emulation