### PR TITLE
adding arm64 support for chromedriver

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,7 +21,7 @@ var platform = process.platform;
 
 var chromedriver_version = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || helper.version;
 if (platform === 'linux') {
-  if (process.arch === 'x64') {
+  if (process.arch === 'arm64' || process.arch === 'x64') {
     platform += '64';
   } else {
     console.log('Only Linux 64 bits supported.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.38.3",
+  "version": "2.42.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Updated install.js to support arm64 architecture. As chromedriver supports linux platform with 64 bits, arm64 architecture is a linux platform with 64 bits.

uname -a
Linux e7fac9d4ba1c 4.10.0-38-generic #42~16.04.1-Ubuntu SMP Tue Oct 10 16:33:57 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux 

Please update the same for arm64 support.