### PR TITLE
Add support for binary file instead of just zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Another option is to use the PATH variable `CHROMEDRIVER_FILEPATH`
 CHROMEDRIVER_FILEPATH=/path/to/chromedriver_mac64.zip
 ```
 
+This variable can be used to set either a `.zip` file or the binary itself, eg:
+
+```shell
+CHROMEDRIVER_FILEPATH=/bin/chromedriver
+```
+
 ## Custom download options
 
 Install through a proxy.

--- a/install.js
+++ b/install.js
@@ -64,6 +64,11 @@ promise = promise.then(function () {
 });
 
 promise.then(function () {
+  if (path.extname(downloadedFile) !== '.zip') {
+    fs.copyFileSync(downloadedFile, path.join(tmpPath, 'chromedriver'));
+    console.log('Skipping zip extraction - binary file found.');
+    return true;
+  }
   return extractDownload(downloadedFile, tmpPath);
 })
   .then(function () {


### PR DESCRIPTION
This is an attempt at closing #139

This change allows users to use CHROMEDRIVER_FILEPATH to point to the
binary directly rather than just the zip file.

The change is transparent, for those using zip files nothing will change