### PR TITLE
Add CHROMEDRIVER_SKIP_DOWNLOAD option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ Use different User-Agent.
 npm config set user-agent "Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0"
 ```
 
+## Skipping chromedriver download
+
+You may wish to skip the downloading of the chromedriver binary file, for example if you know for certain that it is already there or if you want to use a system binary and just use this module as an interface to interact with it.
+
+To achieve this you can use the npm config property `chromedriver_skip_download`.
+
+```shell
+npm install chromedriver --chromedriver_skip_download=true
+```
+
+Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
+
+```
+chromedriver_skip_download=true
+```
+
+Another option is to use the PATH variable `CHROMEDRIVER_SKIP_DOWNLOAD`
+
+```shell
+CHROMEDRIVER_SKIP_DOWNLOAD=true
+```
+
 Running
 -------
 

--- a/install.js
+++ b/install.js
@@ -10,6 +10,12 @@ var path = require('path');
 var del = require('del');
 var util = require('util');
 
+var skipDownload = process.env.npm_config_chromedriver_skip_download || process.env.CHROMEDRIVER_SKIP_DOWNLOAD;
+if (skipDownload) {
+  console.log('Found CHROMEDRIVER_SKIP_DOWNLOAD variable, skipping installation.')
+  return;
+}
+
 var libPath = path.join(__dirname, 'lib', 'chromedriver');
 var cdnUrl = process.env.npm_config_chromedriver_cdnurl || process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
 var configuredfilePath = process.env.npm_config_chromedriver_filepath || process.env.CHROMEDRIVER_FILEPATH;

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var path = require('path');
 var tcpPortUsed = require('tcp-port-used');
 function getPortFromArgs(args) {
@@ -18,7 +19,13 @@ process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + proce
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
 exports.version = '2.43';
 exports.start = function(args, returnPromise) {
-  var cp = require('child_process').spawn(exports.path, args);
+  var command = exports.path;
+  if (!fs.existsSync(command)) {
+    console.log('Could not find chromedriver in default path: ', command);
+    console.log('Falling back to use global chromedriver bin');
+    command = process.platform === 'win32' ? 'chromedriver.exe' : 'chromedriver';
+  }
+  var cp = require('child_process').spawn(command, args);
   cp.stdout.pipe(process.stdout);
   cp.stderr.pipe(process.stderr);
   exports.defaultInstance = cp;


### PR DESCRIPTION
This is an attempt at closing #180 and possibly also #145

This adds the possibility to skip downloading the chromedriver binary
during installation, and fallback to the system binary when a local
binary is not found.