### PR TITLE
Bump chromedriver version to 2.45

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.44';
+exports.version = '2.45';
 exports.start = function(args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.44.1",
+  "version": "2.45.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
**----------ChromeDriver v2.45 (2018-12-10)----------**
https://chromedriver.storage.googleapis.com/2.45/notes.txt

**Supports Chrome v70-72**

- Resolved issue 1997: New Session is not spec compliant [[Pri-1]]
- Resolved issue 2685: Should Assert that the chrome version is compatible [[Pri-2]]
- Resolved issue 2677: Find Element command returns wrong error code when an invalid locator is used [[Pri-2]]
- Resolved issue 2676: Some ChromeDriver status codes are wrong [[Pri-2]]
- Resolved issue 2665: compile error in JS inside of WebViewImpl::DispatchTouchEventsForMouseEvents [[Pri-2]]
- Resolved issue 2658: Window size commands should handle user prompts [[Pri-2]]
- Resolved issue 2684: ChromeDriver doesn't start Chrome correctly with options.addArguments("user-data-dir=") [[Pri-3]]
- Resolved issue 2688: Status command is not spec compliant [[Pri-3]]
- Resolved issue 2654: Add support for strictFileInteractability [[Pri-]]