### PR TITLE
Bump chromedriver version to 73.0.3683.20

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '2.46';
+exports.version = '73.0.3683.20';
 exports.start = function(args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.46.0",
+  "version": "73.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "2.46.0",
+  "version": "73.0.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
ChromeDriver 73.0.3683.20

- Supports Chrome version 73
- Fixed error code returned from Execute Script command in some scenarios
- Made the HTTP server keep connection alive by default
- Fixed Close Window command to correctly handle user prompts
- Fixed error code returned while sending keys to disabled element
- Improved spec compliance of timeout value handling
- Improved spec compliance of Add Cookie command
- Increased HTTP server listening queue length
- Fixed Is Element Displayed command in v0 shadow DOM
- Added warning about Element Clear command behavior change in log file
- Fixed Execute Script command to correctly convert document.all into JSON format
- Improved handling of bad element reference