### PR TITLE
Add chromedriver_filepath support for direct exe paths on Windows

### DIFF
--- a/install.js
+++ b/install.js
@@ -258,7 +258,7 @@ function requestBinary(requestOptions, filePath) {
 
 function extractDownload() {
   if (path.extname(downloadedFile) !== '.zip') {
-    fs.copyFileSync(downloadedFile, path.resolve(tmpPath, 'chromedriver'));
+    fs.copyFileSync(downloadedFile, chromedriverBinaryFilePath);
     console.log('Skipping zip extraction - binary file found.');
     return Promise.resolve();
   }


### PR DESCRIPTION
The `extractDownload` path that handles copying a pre-downloaded, pre-extracted binary specified via `chromedriver_filepath` currently assumes that it should copy to a file named `chromedriver`, rather than using `chromedriver.exe` on Windows like the rest of the code expects.

Fixes #212