### PR TITLE
Automated Chromedriver updates

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ tmp
 Dockerfile
 test-driver.sh
 testInstall.js
+update.js
 *.tgz
 .vscode
 .editorconfig

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ executed as a callback at the end of your tests
 The NPM package version tracks the version of chromedriver that will be installed,
 with an additional build number that is used for revisions to the installer.
 You can use the package version number to install a specific version, or use the
-setting to a specific version. To always install the latest version of Chromedriver,
+setting to a specific version. If there is a new Chromedriver version available which is not yet available as a version of `node-chromedriver`, the npm command `npm run update-chromedriver` in this repository can be used to make the required updates to this module, please submit the change as a PR. To always install the latest version of Chromedriver,
 use `LATEST` as the version number:
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "install": "node install.js",
-    "update": "node update.js"
+    "update-chromedriver": "node update.js"
   },
   "dependencies": {
     "del": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "chromedriver": "./bin/chromedriver"
   },
   "scripts": {
-    "install": "node install.js"
+    "install": "node install.js",
+    "update": "node update.js"
   },
   "dependencies": {
     "del": "^4.1.1",

--- a/update.js
+++ b/update.js
@@ -1,0 +1,37 @@
+const request = require('request');
+const fs = require('fs');
+const execSync = require('child_process').execSync;
+const CURRENT_VERSION = require('./lib/chromedriver').version;
+
+// fetch the latest chromedriver version
+const getLatest = (cb) => {
+  request('https://chromedriver.storage.googleapis.com/LATEST_RELEASE', function (err, response, body) {
+    if (err) {
+      process.exit(1);
+    }
+    return cb(body);
+  });
+};
+
+/* Provided a new Chromedriver version such as 77.0.3865.40:
+   - update the version inside the ./lib/chromedriver helper file e.g. exports.version = '77.0.3865.40';
+   - add a git commit and tag of npm version, e.g. Bump version to 77.0.0
+   - bumps npm package version
+*/
+const writeUpdate = (version) => {
+  const helper = fs.readFileSync('./lib/chromedriver.js', 'utf8');
+  const versionExport = 'exports.version';
+  const regex = new RegExp(`^.*${versionExport}.*$`, 'gm');
+  const updated = helper.replace(regex, `${versionExport} = '${version}';`);
+  fs.writeFileSync('./lib/chromedriver.js', updated, 'utf8');
+  execSync(`git add . && git commit -m "Bump version to ${version.slice(0, 2)}.0.0" && npm version ${version.slice(0, 2)}.0.0`);
+};
+
+getLatest(function (version) {
+  if (CURRENT_VERSION === version) {
+    console.log('Chromedriver version is up to date.');
+  } else {
+    writeUpdate(version);
+    console.log(`Chromedriver version updated to ${version}`);
+  }
+});

--- a/update.js
+++ b/update.js
@@ -26,7 +26,7 @@ const writeUpdate = (version) => {
   const updated = helper.replace(regex, `${versionExport} = '${version}';`);
   fs.writeFileSync('./lib/chromedriver.js', updated, 'utf8');
   const packageVersion = `${version.slice(0, 2)}.0.0`;
-  execSync(`npm version ${packageVersion} git-tag-version=false && git add . && git tag ${packageVersion} && git commit -m "Bump version to ${packageVersion}"`);
+  execSync(`npm version ${packageVersion} --git-tag-version=false && git add . && git commit -m "Bump version to ${packageVersion}" && git tag ${packageVersion}`);
 };
 
 getLatest((version) => {

--- a/update.js
+++ b/update.js
@@ -15,8 +15,9 @@ const getLatest = (cb) => {
 
 /* Provided a new Chromedriver version such as 77.0.3865.40:
    - update the version inside the ./lib/chromedriver helper file e.g. exports.version = '77.0.3865.40';
-   - add a git commit and tag of npm version, e.g. Bump version to 77.0.0
-   - bumps npm package version
+   - bumps package.json version number
+   - add a git tag using the new node-chromedriver version
+   - add a git commit, e.g. Bump version to 77.0.0
 */
 const writeUpdate = (version) => {
   const helper = fs.readFileSync('./lib/chromedriver.js', 'utf8');
@@ -24,7 +25,8 @@ const writeUpdate = (version) => {
   const regex = new RegExp(`^.*${versionExport}.*$`, 'gm');
   const updated = helper.replace(regex, `${versionExport} = '${version}';`);
   fs.writeFileSync('./lib/chromedriver.js', updated, 'utf8');
-  execSync(`git add . && git commit -m "Bump version to ${version.slice(0, 2)}.0.0" && npm version ${version.slice(0, 2)}.0.0`);
+  const packageVersion = `${version.slice(0, 2)}.0.0`;
+  execSync(`npm version ${packageVersion} git-tag-version=false && git add . && git tag ${packageVersion} && git commit -m "Bump version to ${packageVersion}"`);
 };
 
 getLatest((version) => {

--- a/update.js
+++ b/update.js
@@ -5,7 +5,7 @@ const CURRENT_VERSION = require('./lib/chromedriver').version;
 
 // fetch the latest chromedriver version
 const getLatest = (cb) => {
-  request('https://chromedriver.storage.googleapis.com/LATEST_RELEASE', function (err, response, body) {
+  request('https://chromedriver.storage.googleapis.com/LATEST_RELEASE', (err, response, body) => {
     if (err) {
       process.exit(1);
     }
@@ -27,7 +27,7 @@ const writeUpdate = (version) => {
   execSync(`git add . && git commit -m "Bump version to ${version.slice(0, 2)}.0.0" && npm version ${version.slice(0, 2)}.0.0`);
 };
 
-getLatest(function (version) {
+getLatest((version) => {
   if (CURRENT_VERSION === version) {
     console.log('Chromedriver version is up to date.');
   } else {


### PR DESCRIPTION
At the moment, it is a bit of a manual process to get a new Chromedriver release, pulled into this project and published to NPM.

It would be easier for the maintainer and consumers of the module if this could be more automated.

This PR offers a new npm script `npm run update-chromedriver` which will find the latest version of Chromedriver which is available. If there is a newer once available which is newer that what is currently in the project, it will

- bump version in lib/chromedriver.js
- bump package.json version
- git tag version
- git commit update message

If this script works well locally, we could look at getting it running on a cron schedule, once per day(maybe using Github Actions?). That way it should be easy to get the latest Chromedriver.