### PR TITLE
Support XDG_CACHE_HOME and make npm_config_tmp work

### DIFF
--- a/install.js
+++ b/install.js
@@ -128,9 +128,10 @@ function verifyIfChromedriverIsAvailableAndHasCorrectVersion() {
 function findSuitableTempDirectory() {
   const now = Date.now();
   const candidateTmpDirs = [
-    process.env.TMPDIR || process.env.TMP || process.env.npm_config_tmp,
+    process.env.npm_config_tmp,
+    process.env.XDG_CACHE_HOME,
+    // Platform specific default, including TMPDIR/TMP/TEMP env
     os.tmpdir(),
-    '/tmp',
     path.join(process.cwd(), 'tmp')
   ];
 


### PR DESCRIPTION
Ref #72.

* For npm_config_tmp to work as (optional) override for the default
  temporary directory, it has to be checked first, not last
  in the chain of default-operator checks.

* Add support for XDG_CACHE_HOME which some XDG-compliant environments
  will set to a directory that is persisted between CI runs and such.

  The XDG Cache home concept is ideal for this purpose because
  node-chromedriver takes care to clean up after itself and uses a
  deterministic filename. As such, it won't grow out of control and can
  be safely cached and persisted when XDG is provided.

  This way, downstream users of node-chromedriver are not required to
  set npm_config_tmp to a persisted directory, which can be undesirable
  due to the inherit nature and expectation of a temp directory.
  E.g. software tends to place files with random files name here, or
  leave behind large files, a directory with files that would grow
  rapidly if persisted between subsequent CI runs.

* Remove the redundant manual handling of TMPDIR, TMP and "/tmp".
  These predate the addition of os.tmpdir() by 60c470675b71f, which
  handles all these already. This code appears to be inspired by
  <https://github.com/Medium/phantomjs/blob/v2.1.8/install.js#L107>,
  which also does not have these additional checks.