### PR TITLE
Bump ChromeDriver to 78.0.3904.70

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '77.0.3865.40';
+exports.version = '78.0.3904.70';
 exports.start = function(args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "77.0.0",
+  "version": "78.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "77.0.0",
+  "version": "78.0.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
Chromedriver 78.0.3904.70 ([changelog](https://chromedriver.storage.googleapis.com/78.0.3904.70/notes.txt)) has been released for Chrome 78 ([release notes](https://blog.chromium.org/2019/09/chrome-78-beta-new-houdini-api-native.html)).