### PR TITLE
Bump version to 79.0.0

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '78.0.3904.70';
+exports.version = '79.0.3945.36';
 exports.start = function(args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "78.0.1",
+  "version": "79.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "78.0.1",
+  "version": "79.0.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
As of earlier today Chrome has moved their stable release to 79. The https://chromedriver.storage.googleapis.com/LATEST_RELEASE however did not get the update. To further the fun, Travis CI is pulling 79 as `stable`.

If possible, it'd be wonderful to update to chromedriver 79, publish a new package, and resolve the discrepancy with Travis.