### PR TITLE
Allow specifying the latest version for a specific major release

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ Another option is to use env variable `CHROMEDRIVER_VERSION`.
 CHROMEDRIVER_VERSION=LATEST npm install chromedriver
 ```
 
+You can force the latest release for a specific major version by specifying `LATEST_{VERSION_NUMBER}`:
+
+```shell
+CHROMEDRIVER_VERSION=LATEST_80 npm install chromedriver
+```
+
 You can also force a different version of chromedriver by replacing `LATEST` with a version number:
 
 ```shell

--- a/install.js
+++ b/install.js
@@ -50,8 +50,15 @@ let chromedriverBinaryFilePath;
 let downloadedFile = '';
 
 Promise.resolve().then(function () {
-  if (chromedriver_version === 'LATEST')
-    return getLatestVersion(getRequestOptions(cdnUrl + '/LATEST_RELEASE'));
+  if (chromedriver_version === 'LATEST') {
+    return getLatestVersion(getRequestOptions(`${cdnUrl}/LATEST_RELEASE`));
+  } else {
+    const latestReleaseForVersionMatch = chromedriver_version.match(/LATEST_(\d+)/);
+    if (latestReleaseForVersionMatch) {
+      const majorVersion = latestReleaseForVersionMatch[1];
+      return getLatestVersion(getRequestOptions(`${cdnUrl}/LATEST_RELEASE_${majorVersion}`));
+    }
+  }
 })
 .then(() => {
   tmpPath = findSuitableTempDirectory();


### PR DESCRIPTION
Since #222 got closed and Chromium [explicitly discourages using `LATEST_RELEASE` in order to get the latest version](https://chromedriver.chromium.org/downloads/version-selection), I added a way to force the download of the latest version for a specific major release. This somewhat addresses the problem in #244.