### PR TITLE
[master] Fix google chrome version detection for MacOS

### DIFF
--- a/install.js
+++ b/install.js
@@ -55,8 +55,11 @@ Promise.resolve().then(function () {
   if (detect_chromedriver_version === 'true') {
     // Refer http://chromedriver.chromium.org/downloads/version-selection
     return getChromeVersion().then(function (chromeVersion) {
-      console.log("Your Chrome version is " + chromeVersion);
-      const chromeVersionWithoutPatch = /^(.*?)\.\d+$/.exec(chromeVersion)[1];
+      const cleanChromeDriverVersion = chromeVersion.trim();
+
+      console.log("Your Chrome version is " + cleanChromeDriverVersion);
+
+      const chromeVersionWithoutPatch = /^(.*?)\.\d+$/.exec(cleanChromeDriverVersion)[1];
       return getChromeDriverVersion(getRequestOptions(cdnUrl + '/LATEST_RELEASE_' + chromeVersionWithoutPatch));
     }).then(function () {
       console.log("Compatible ChromeDriver version is " + chromedriver_version);


### PR DESCRIPTION
Given the following snippet (used to get the chrome version on Macos):

```js
(async () => {
  const { getChromeVersion } = require('@testim/chrome-version');
  const version = await getChromeVersion();
  console.log('chrome-version: (%s)', version);
})();
```

The execution result is (note the line break):

```bash
chrome-version: (79.0.3945.130
)
```

As opposed to:

```bash
chrome-version: (79.0.3945.130)
```

Which breaks the following expression:

```js
/^(.*?)\.\d+$/.exec(' 79.0.3945.130\n')[1]
```

With the error below:

```bash
TypeError: Cannot read property '1' of null
```

A `.trim()` over the chrome driver version fix the issue
