### PR TITLE
let it works in mac book m1

### DIFF
--- a/install.js
+++ b/install.js
@@ -81,7 +81,7 @@ function validatePlatform() {
       process.exit(1);
     }
   } else if (thePlatform === 'darwin' || thePlatform === 'freebsd') {
-    if (process.arch === 'x64') {
+    if (process.arch === 'x64' || process.arch == 'arm64') {
       thePlatform = 'mac64';
     } else {
       console.log('Only Mac 64 bits supported.');


### PR DESCRIPTION
Fix #289 

I have test this patch in mac book pro m1:
```
lifubang@bogon node-chromedriver % node ./install.js 
Current existing ChromeDriver binary is unavailable, proceeding with download and extraction.
Downloading from file:  https://npm.taobao.org/mirrors/chromedriver/87.0.4280.20/chromedriver_mac64.zip
Saving to file: /var/folders/h2/6c34nh_146q83y6lh0twr0s80000gn/T/87.0.4280.20/chromedriver/chromedriver_mac64.zip
Received 1026K...
Received 2066K...
Received 3106K...
Received 4146K...
Received 5186K...
Received 6226K...
Received 7266K...
Received 7712K total.
Extracting zip contents to /var/folders/h2/6c34nh_146q83y6lh0twr0s80000gn/T/87.0.4280.20/chromedriver.
Copying to target path /Users/lifubang/dev/github/node-chromedriver/lib/chromedriver
Fixing file permissions.
Done. ChromeDriver binary available at /Users/lifubang/dev/github/node-chromedriver/lib/chromedriver/chromedriver
```

Signed-off-by: lifubang <lifubang@acmcoder.com>