### PR TITLE
Bump version to 90.0.0

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '89.0.4389.23';
+exports.version = '90.0.4430.24';
 exports.start = function (args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "89.0.0",
+  "version": "90.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "89.0.0",
+  "version": "90.0.0",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
The update script uses this URL: https://chromedriver.storage.googleapis.com/LATEST_RELEASE , which still points to version 89.x. However, version 90 is available, even though that URL has not yet updated: https://chromedriver.chromium.org/downloads

So, I temporarily hard-coded the version as `90.0.4430.24` (instead of using the `LATEST_RELEASE` alias) to produce this PR.