### PR TITLE
Added feature to allow downloading chrome driver on run time!

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Use different User-Agent.
 npm config set user-agent "Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0"
 ```
 
+## Custom Target download location
+You may want to download and place the chromedriver binary to a custom target location. This can be achieved by setting the below flag
+
+    npm install chromedriver --chromedriver_download_to_target_folder="C:\Users\output" --chromedriver-force-download
+
 ## Skipping chromedriver download
 
 You may wish to skip the downloading of the chromedriver binary file, for example if you know for certain that it is already there or if you want to use a system binary and just use this module as an interface to interact with it.
@@ -155,6 +160,21 @@ var driver = new webdriver.Builder()
 
 The path will be added to the process automatically, you don't need to configure it.
 But you can get it from `require('chromedriver').path` if you want it.
+
+## Download chromedriver via node
+
+    var chromedriver =  require('chromedriver');
+    chromedriver.download()
+
+you can pass all the commandline flags as:
+
+    var chromedriver =  require('chromedriver');
+    process.env.detect_chromedriver_version = true
+    process.env.chromedriver_force_download = true    
+    process.env.chromedriver_download_to_target_folder="C:/Users/output" 
+    chromedriver.download()
+
+chromedriver.download() returns a **promise**
 
 ## Running via node
 

--- a/install.js
+++ b/install.js
@@ -33,7 +33,7 @@ let chromedriver_version = process.env.npm_config_chromedriver_version || proces
 let chromedriverBinaryFilePath;
 let downloadedFile = '';
 
-(async function install() {
+let install =(async function install() {
   try {
     if (detect_chromedriver_version === 'true') {
       // Refer http://chromedriver.chromium.org/downloads/version-selection
@@ -68,7 +68,7 @@ let downloadedFile = '';
     console.error('ChromeDriver installation failed', err);
     process.exit(1);
   }
-})();
+});
 
 function validatePlatform() {
   /** @type string */
@@ -337,3 +337,9 @@ function Deferred() {
   }.bind(this));
   Object.freeze(this);
 }
+
+if (!module.parent) {
+  install();
+} 
+
+module.exports = {install};

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -45,3 +45,7 @@ exports.stop = function () {
     exports.defaultInstance.kill();
   }
 };
+exports.download = async function () {
+  return require("../install.js").install();
+}
+


### PR DESCRIPTION
Updated Read me to include details:

Now you can download chromedriver from your scripts like 

```
var chromedriver = require('chromedriver');
process.env.detect_chromedriver_version = true;
process.env.chromedriver_force_download = true;
process.env.chromedriver_download_to_target_folder = "C:/Users/output";



chromedriver.download().then(()=>{
console.log("completed")})
```