### PR TITLE
Bump to 98.0.4758.102

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '98.0.4758.80';
+exports.version = '98.0.4758.102';
 exports.start = function (args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromedriver",
-  "version": "98.0.0",
+  "version": "98.0.1",
   "keywords": [
     "chromedriver",
     "selenium"


### PR DESCRIPTION
This bug https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999 is now fixed with a release of 98.0.4758.102.

TLDR: some keystrokes are broken in 98.0.4758.80  (e.g. DEL button behaves differently, the character of '\\' fails as unrecognized etc.). For example element.sendKeys(webdriver.Key.DELETE) doesn't work.