### PR TITLE
fix: Check for stdout in sysctl

### DIFF
--- a/install.js
+++ b/install.js
@@ -355,9 +355,20 @@ function isEmulatedRosettaEnvironment() {
   const archName = child_process.spawnSync('uname', ['-m']).stdout.toString().trim();
 
   if (archName === 'x86_64') {
-    const processTranslated = child_process.spawnSync('sysctl', ['-in', 'sysctl.proc_translated'])
-      .stdout.toString()
-      .trim();
+    const proc = child_process.spawnSync('sysctl', ['-in', 'sysctl.proc_translated']);
+
+    // When run with `-in`, the return code is 0 even if there is no `sysctl.proc_translated`
+    if(proc.status) {
+        throw new Error('Unexpected return code from sysctl: ' + proc.status);
+    }
+
+    // If there is no `sysctl.proc_translated` (i.e. not rosetta) then nothing is printed to
+    // stdout
+    if(!proc.stdout) {
+        return false
+    }
+
+    const processTranslated = proc.stdout.toString().trim();
 
     return processTranslated === '1';
   }


### PR DESCRIPTION
Fixes #357 

This fixes the `sysctl` call on Intel macs, where `sysctl` doesn't
output anything (in which case `stdout` is `null`).