### PR TITLE
Update mirror url

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ To use a mirror of the ChromeDriver binaries use npm config property `chromedriv
 Default is `https://chromedriver.storage.googleapis.com`.
 
 ```shell
-npm install chromedriver --chromedriver_cdnurl=https://npm.taobao.org/mirrors/chromedriver
+npm install chromedriver --chromedriver_cdnurl=https://npmmirror.com/mirrors/chromedriver
 ```
 
 Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
 
 ```
-chromedriver_cdnurl=https://npm.taobao.org/mirrors/chromedriver
+chromedriver_cdnurl=https://npmmirror.com/mirrors/chromedriver
 ```
 
 Another option is to use PATH variable `CHROMEDRIVER_CDNURL`.
 
 ```shell
-CHROMEDRIVER_CDNURL=https://npm.taobao.org/mirrors/chromedriver npm install chromedriver
+CHROMEDRIVER_CDNURL=https://npmmirror.com/mirrors/chromedriver npm install chromedriver
 ```
 
 ## Custom binaries file


### PR DESCRIPTION
npm.taobao.org is deprecated
see details: https://npmmirror.com/