### PR TITLE
npm ignore tsconfig.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,4 +14,4 @@ shippable.yml
 azure-pipelines.yml
 .github
 .travis.yml
-
+tsconfig.json


### PR DESCRIPTION
I noticed in https://app.renovatebot.com/package-diff?name=chromedriver&from=107.0.2&to=107.0.3 that this file was added to the bundle, and I assumed it was accidental.