### PR TITLE
Add s390x cpu support to `install.js` and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: [build, build_arm64, build_proxy]
+    needs: [build, build_arm64, build_s390x, build_proxy]
     if: success() && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,51 @@ jobs:
               echo "Binary not found at $BIN"
               exit 1
             fi
+  
+  build_s390x:
+    name: Build s390x
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["16", "18", "19", "20"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.1.1
+        name: Verify install
+        id: build
+        with:
+          arch: s390x
+          distro: ubuntu20.04
+          env: | # this is just so we can cache each version
+            GITHUB_WORKFLOW: ${{ github.workflow }}-${{ github.job }}-${{ matrix.node }}
+          dockerRunArgs: |
+            --volume "$PWD:/app"
+          githubToken: ${{ github.token }}
+          install: |
+            set -euo pipefail
+            apt-get update
+            apt-get -y install xz-utils curl libnss3
+            curl -fsSL --output sha https://nodejs.org/dist/latest-v${{ matrix.node }}.x/SHASUMS256.txt
+            FULL_FILE=`grep 'node-v${{ matrix.node }}.*-linux-s390x.tar.gz' sha | tr -s ' ' | cut -d' ' -f2`
+            NODE_VERSION=`echo $FULL_FILE | grep --color=never -Eo '[0-9]{2,}\.[0-9]{1,}\.[0-9]{1,}'`
+            echo "Node version is $NODE_VERSION"
+            ARCH=s390x
+            curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz"
+            tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
+            rm sha
+            rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz"
+            npm install -g npm@latest
+          run: |
+            node --version
+            npm --version
+            cd /app
+            npm ci --no-progress
+            BIN="./lib/chromedriver/chromedriver"
+            if ! [ -e $BIN ]; then
+              echo "Binary not found at $BIN"
+              exit 1
+            fi
 
   build_proxy:
     name: Build with proxy

--- a/install.js
+++ b/install.js
@@ -83,7 +83,7 @@ function validatePlatform() {
   /** @type string */
   let thePlatform = process.platform;
   if (thePlatform === 'linux') {
-    if (process.arch === 'arm64' || process.arch === 'x64') {
+    if (process.arch === 'arm64' || process.arch === 's390x' || process.arch === 'x64') {
       thePlatform += '64';
     } else {
       console.log('Only Linux 64 bits supported.');


### PR DESCRIPTION
Currently `node-chromedriver` only supports Intel and arm64 cpu. This PR aims to add s390x support to this repo and the CI pipeline.