### PR TITLE
Use latest chromedriver version 115.0.5790.170

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -17,7 +17,7 @@ function getPortFromArgs(args) {
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;
 exports.path = process.platform === 'win32' ? path.join(__dirname, 'chromedriver', 'chromedriver.exe') : path.join(__dirname, 'chromedriver', 'chromedriver');
-exports.version = '115.0.5790.102';
+exports.version = '115.0.5790.170';
 exports.start = function (args, returnPromise) {
   let command = exports.path;
   if (!fs.existsSync(command)) {


### PR DESCRIPTION
Use latest chromedriver version that fixes a bug in the chrome binary resolution and solves the error:

`An error occurred while creating a new ChromeDriver session: [WebDriverError] unknown error: cannot find Chrome binary`

See: https://github.com/GoogleChromeLabs/chrome-for-testing/issues/30

and: https://bugs.chromium.org/p/chromium/issues/detail?id=1466427