### PR TITLE
Creates the intermediate tmp folder before attempting to copy CHROMEDRIVER_FILEPATH to it.

### DIFF
--- a/install.js
+++ b/install.js
@@ -359,6 +359,7 @@ async function requestBinary(requestOptions, filePath) {
  */
 async function extractDownload(dirToExtractTo, chromedriverBinaryFilePath, downloadedFile) {
   if (path.extname(downloadedFile) !== '.zip') {
+    fs.mkdirSync(path.dirname(chromedriverBinaryFilePath), {recursive: true});
     fs.copyFileSync(downloadedFile, chromedriverBinaryFilePath);
     console.log('Skipping zip extraction - binary file found.');
     return;


### PR DESCRIPTION
Copying the binary no longer worked, unless the destination tmp folder already existed.

Steps to reproduce:
- rm -Rf /tmp/117.0.5938.92/chromedriver/
- CHROMEDRIVER_FILEPATH="/yourpathto/chromedriver" node node_modules/chromedriver/install.js

Failed with:
```
ChromeDriver installation failed Error: ENOENT: no such file or directory, copyfile '/tmp/chromedriver' -> '/tmp/117.0.5938.92/chromedriver/chromedriver-linux64/chromedriver'
    at Object.copyFileSync (node:fs:2894:3)
    at extractDownload (/home/anastasios/Sources/cloud/web/node_modules/chromedriver/install.js:364:8)
    at install (/home/anastasios/Sources/cloud/web/node_modules/chromedriver/install.js:70:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -2,
  syscall: 'copyfile',
  code: 'ENOENT',
  path: '/tmp/chromedriver',
  dest: '/tmp/117.0.5938.92/chromedriver/chromedriver-linux64/chromedriver'
}
```

After this change it succeeds.