### PR TITLE
Update default binary CDN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ how these urls work.
 
 Npm config:
 For metadata use `chromedriver_cdnurl`. The default is `https://googlechromelabs.github.io`.
-For binaries use `chromedriver_cdnbinariesurl`. The default is `https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing`.
+For binaries use `chromedriver_cdnbinariesurl`. The default is `https://storage.googleapis.com/chrome-for-testing-public`.
 
 ```shell
 npm install chromedriver --chromedriver_cdnurl=https://npmmirror.com/metadata --chromedriver_cdnbinariesurl=https://npmmirror.com/binaries

--- a/install.js
+++ b/install.js
@@ -63,7 +63,7 @@ if (skipDownload) {
     const chromedriverIsAvailable = await verifyIfChromedriverIsAvailableAndHasCorrectVersion(chromedriverVersion, chromedriverBinaryFilePath);
     if (!chromedriverIsAvailable) {
       console.log('Current existing ChromeDriver binary is unavailable, proceeding with download and extraction.');
-      const cdnBinariesUrl = (process.env.npm_config_chromedriver_cdnbinariesurl || process.env.CHROMEDRIVER_CDNBINARIESURL || 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing').replace(/\/+$/, '');
+      const cdnBinariesUrl = (process.env.npm_config_chromedriver_cdnbinariesurl || process.env.CHROMEDRIVER_CDNBINARIESURL || 'https://storage.googleapis.com/chrome-for-testing-public').replace(/\/+$/, '');
       downloadedFile = await downloadFile(useLegacyMethod ? legacyCdnUrl : cdnBinariesUrl, useLegacyMethod, downloadedFile, chromedriverVersion, platform);
       await extractDownload(extractDirectory, chromedriverBinaryFilePath, downloadedFile);
     }


### PR DESCRIPTION
In the last couple of days, the CDN URL has changed from:

```
https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing
```

[Wayback Machine][1]

to:

```
https://storage.googleapis.com/chrome-for-testing-public
```

[Current][2]

This change updates the default to match the current URL

[1]: https://web.archive.org/web/20240213030506/https://googlechromelabs.github.io/chrome-for-testing/#stable
[2]: https://googlechromelabs.github.io/chrome-for-testing/#stable