### PR TITLE
Allow to use the Installer programatically

### DIFF
--- a/install.js
+++ b/install.js
@@ -475,7 +475,6 @@ function Deferred() {
   Object.freeze(this);
 }
 
+module.exports = Installer;
 if (require.main === module)
-  new Installer().install();
-else if (process.env.NODE_ENV === 'test')
-  module.exports = Installer;
+  new Installer().install();  


### PR DESCRIPTION
Allow using Installer programatically regardless of the NODE_ENV variable value.

I was looking for a way to install chromedriver as a javascript function.
I did this in the beginning of the file:

`let previousNodeEnv = process.env.NODE_ENV
process.env.NODE_ENV = 'test' //this is needed to get the install file from chromedriver/install
process.env.DETECT_CHROMEDRIVER_VERSION = true
const ChromedriverInstaller = require('chromedriver/install')
process.env.NODE_ENV = previousNodeEnv`

It would be nice if I could avoid those env variables and call the method with parameters.
Or at least avoid having to set the NODE_ENV, which is the goal of this PR :)