### PR TITLE
Add RISC-V 64-bit Support with --chromedriver_filepath Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,12 @@ This variable can be used to set either a `.zip` file or the binary itself, eg:
 ```shell
 CHROMEDRIVER_FILEPATH=/bin/chromedriver
 ```
+## Installing on RISC-V 64-bit Systems
+Chromedriver does not provide an official binary for RISC-V 64-bit architectures. To install on a RISC-V system, you must supply your own Chromedriver binary using the `--chromedriver_filepath` option. For example:
 
+```bash
+npm install chromedriver --chromedriver_filepath=/path/to/chromedriver
+```
 ## Custom download options
 
 Install through a proxy.

--- a/install.js
+++ b/install.js
@@ -95,12 +95,12 @@ class Installer {
         const configuredfilePath = process.env.npm_config_chromedriver_filepath || process.env.CHROMEDRIVER_FILEPATH;
         if (!configuredfilePath) {
           console.error(
-            'Error: RISC-V detected: No official Chromedriver binary is available for RISC-V 64-bit. >
+            'Error: RISC-V detected: No official Chromedriver binary is available for RISC-V 64-bit. ' +
             'Please provide a local Chromedriver binary using the --chromedriver_filepath option. ' +
             'Example: npm install chromedriver --chromedriver_filepath=/path/to/chromedriver ' +
             'You may need to build Chromedriver from source or obtain it from a third-party source.'
           );
-        // process.exit(1);
+          process.exit(1);
         }
         // Return a placeholder platform; actual file will come from configuredfilePath
         return 'linux64'; // Compatible with downstream logic, though download is skipped

--- a/install.js
+++ b/install.js
@@ -90,6 +90,20 @@ class Installer {
     if (thePlatform === 'linux') {
       if (process.arch === 'arm64' || process.arch === 's390x' || process.arch === 'x64' || process.arch === 'riscv64') {
         return 'linux64';
+      } else if (process.arch === 'riscv64') {
+        // Check if --chromedriver_filepath is provided via env vars
+        const configuredfilePath = process.env.npm_config_chromedriver_filepath || process.env.CHROME>
+        if (!configuredfilePath) {
+          console.error(
+            'Error: RISC-V detected: No official Chromedriver binary is available for RISC-V 64-bit. >
+            'Please provide a local Chromedriver binary using the --chromedriver_filepath option. ' +
+            'Example: npm install chromedriver --chromedriver_filepath=/path/to/chromedriver ' +
+            'You may need to build Chromedriver from source or obtain it from a third-party source.'
+          );
+        // process.exit(1);
+        }
+        // Return a placeholder platform; actual file will come from configuredfilePath
+        return 'linux64'; // Compatible with downstream logic, though download is skipped
       } else {
         console.error('Only Linux 64 bits supported.');
         process.exit(1);

--- a/install.js
+++ b/install.js
@@ -88,7 +88,7 @@ class Installer {
   getPlatform(chromedriverVersion) {
     const thePlatform = process.platform;
     if (thePlatform === 'linux') {
-      if (process.arch === 'arm64' || process.arch === 's390x' || process.arch === 'x64' || process.arch === 'riscv64') {
+      if (process.arch === 'arm64' || process.arch === 's390x' || process.arch === 'x64') {
         return 'linux64';
       } else if (process.arch === 'riscv64') {
         // Check if --chromedriver_filepath is provided via env vars

--- a/install.js
+++ b/install.js
@@ -92,7 +92,7 @@ class Installer {
         return 'linux64';
       } else if (process.arch === 'riscv64') {
         // Check if --chromedriver_filepath is provided via env vars
-        const configuredfilePath = process.env.npm_config_chromedriver_filepath || process.env.CHROME>
+        const configuredfilePath = process.env.npm_config_chromedriver_filepath || process.env.CHROMEDRIVER_FILEPATH;
         if (!configuredfilePath) {
           console.error(
             'Error: RISC-V detected: No official Chromedriver binary is available for RISC-V 64-bit. >

--- a/install.js
+++ b/install.js
@@ -88,7 +88,7 @@ class Installer {
   getPlatform(chromedriverVersion) {
     const thePlatform = process.platform;
     if (thePlatform === 'linux') {
-      if (process.arch === 'arm64' || process.arch === 's390x' || process.arch === 'x64') {
+      if (process.arch === 'arm64' || process.arch === 's390x' || process.arch === 'x64' || process.arch === 'riscv64') {
         return 'linux64';
       } else {
         console.error('Only Linux 64 bits supported.');


### PR DESCRIPTION
### Description
This PR adds initial support for RISC-V 64-bit systems to the `chromedriver` npm package. Since the Chrome team doesn’t provide an official RISC-V binary, this change ensures the package can still install on RISC-V by requiring a local binary via `--chromedriver_filepath`.

### Changes
- **install.js**: Added a check for `process.arch === 'riscv64'`. If detected and `--chromedriver_filepath` isn’t provided, it throws a helpful error:
- **README.md**: added Instruction for riscv users.

### Testing
- Tested on my RISC-V system:
- Without `--chromedriver_filepath`: Fails with the error message.
- Non-RISC-V systems should be unaffected.