### PR TITLE
chore: upgrade axios to 1.12.0 to address CVE-2025-58754

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.7.4",
+        "axios": "^1.12.0",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "proxy-agent": "^6.4.0",
@@ -1563,9 +1563,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@testim/chrome-version": "^1.1.4",
-    "axios": "^1.7.4",
+    "axios": "^1.12.0",
     "compare-versions": "^6.1.0",
     "extract-zip": "^2.0.1",
     "proxy-agent": "^6.4.0",


### PR DESCRIPTION
This PR addresses a high-level security vulnerability reported for axios for versions 1.11.0 and below: [CVE-2025-58754](https://www.cve.org/CVERecord?id=CVE-2025-58754).

Axios has been upgraded to use a minimum version of 1.12.0, which patches the vulnerability.