### PR TITLE
fix: add null check for regex exec result in port parsing

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -9,8 +9,15 @@ function getPortFromArgs(args) {
   const portArg = args.find(function (arg) {
     return portRegexp.test(arg);
   });
-  if (portArg)
-    port = parseInt(portRegexp.exec(portArg)[1]);
+  if (portArg) {
+    const match = portRegexp.exec(portArg);
+    if (match && match[1]) {
+      const parsed = parseInt(match[1], 10);
+      if (!isNaN(parsed)) {
+        port = parsed;
+      }
+    }
+  }
   return port;
 }
 process.env.PATH = path.join(__dirname, 'chromedriver') + path.delimiter + process.env.PATH;


### PR DESCRIPTION
## Summary
- `portRegexp.exec(portArg)` can return `null`, causing `null[1]` TypeError
- Added null check on the exec result before accessing capture group
- Added radix parameter to `parseInt` (10) and `isNaN` validation

## Test plan
- [ ] Verify `--port=9515` still works correctly
- [ ] Verify default port (9515) is used when no `--port` flag is provided
- [ ] Verify malformed `--port=` values fall back to default gracefully