### PR TITLE
[Security] bump axios to >=1.15.0 (CVE-2026-40175 / GHSA-fvcv-3m26-pcqx — CVSS 9.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "proxy-agent": "^6.5.0",
@@ -2050,21 +2050,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
-    },
-    "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.2.0",
@@ -5191,10 +5185,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.0.0.tgz",
-      "integrity": "sha512-h2lD3OfRraP3R51rNFKIE8nX+qoLr1mE74X91YhVxtDbt+OD6ntoNZv56+JgI4RCdtwQ5eexsOk1KdOQDfvPCQ==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@testim/chrome-version": "^1.1.4",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "compare-versions": "^6.1.0",
     "extract-zip": "^2.0.1",
     "proxy-agent": "^6.5.0",


### PR DESCRIPTION
## Summary      
                                                                                                                                                                                                                            
  `node-chromedriver` currently depends on `axios@1.13.5`, which is affected by a critical vulnerability.                                                                                                                        
   
  - **Advisory**: [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx)                                                                                                                                  
  - **CVE**: CVE-2026-40175
  - **CVSS**: 9.9 (Critical)                                                                                                                                                                                                
                                                                                                                                                                                                                            
  ## Vulnerability
                                                                                                                                                                                                                            
  Axios fails to sanitize HTTP header values for CRLF characters, enabling header injection / request smuggling attacks. When combined with prototype pollution from any dependency in the chain, it can lead to cloud      
  metadata exfiltration (e.g. AWS IMDSv2 token bypass).
                                                                                                                                                                                                                            
  **Affected versions**: `>= 1.0.0 < 1.15.0`

  ## Fix                                                                                                                                                                                                                    
   
  Bump the `axios` dependency to `>= 1.15.0.