### PR TITLE
fix: don't override --port=0 with the default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,21 @@ chromedriver
   });
 ```
 
+Passing `--port=0` asks the OS for a free port, which avoids colliding on the
+default port when several instances run in parallel. The port that was assigned
+is on the returned process once the promise resolves:
+
+```javascript
+chromedriver
+  .start(['--port=0'], true)
+  .then((cp) => {
+    console.log('chromedriver is ready on port ' + cp.port);
+  });
+```
+
+Without the promise there is nothing to wait on, so with `--port=0` the assigned
+port is not known and `cp.port` is left unset.
+
 Note: if your tests are ran asynchronously, chromedriver.stop() will have to be
 executed as a callback at the end of your tests
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -40,7 +40,7 @@ function start(args, returnPromise) {
     command = process.platform === "win32" ? "chromedriver.exe" : "chromedriver";
   }
   let port = getPortFromArgs(args);
-  if (!port) {
+  if (port === undefined) {
     args.push("--port=9515");
     port = 9515;
   }
@@ -49,6 +49,9 @@ function start(args, returnPromise) {
   cp.stderr.pipe(process.stderr);
   defaultInstance = cp;
   if (!returnPromise) return cp;
+  // with --port=0 the OS assigns a random port we cannot know here, so there is
+  // nothing to poll; resolve as soon as the process is spawned.
+  if (port === 0) return Promise.resolve(cp);
   const pollInterval = 100;
   const timeout = 10000;
   return tcpPortUsed.waitUntilUsed(port, pollInterval, timeout).then(function () {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -41,7 +41,7 @@ function start(args, returnPromise) {
     command = process.platform === "win32" ? "chromedriver.exe" : "chromedriver";
   }
   let port = getPortFromArgs(args);
-  if (!port) {
+  if (port === undefined) {
     args.push("--port=9515");
     port = 9515;
   }
@@ -50,6 +50,9 @@ function start(args, returnPromise) {
   cp.stderr.pipe(process.stderr);
   defaultInstance = cp;
   if (!returnPromise) return cp;
+  // with --port=0 the OS assigns a random port we cannot know here, so there is
+  // nothing to poll; resolve as soon as the process is spawned.
+  if (port === 0) return Promise.resolve(cp);
   const pollInterval = 100;
   const timeout = 10000;
   return tcpPortUsed.waitUntilUsed(port, pollInterval, timeout).then(function () {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -23,13 +23,64 @@ function getPortFromArgs(args) {
   const port = parseInt(portRegexp.exec(portArg)[1]);
   return port;
 }
+/**
+ * Resolves with the port chromedriver reports on its startup line, which it
+ * prints once it is listening. With `--port=0` the OS assigns an ephemeral
+ * port, so this is the only way to learn which one it got.
+ * @param {import("node:child_process").ChildProcessWithoutNullStreams} cp
+ * @param {number} timeout
+ * @returns {Promise<number>}
+ */
+function getPortFromStdout(cp, timeout) {
+  const startedRegexp = /ChromeDriver was started successfully on port (\d+)\./;
+  return new Promise(function (resolve, reject) {
+    let output = "";
+    const timer = setTimeout(function () {
+      finish(
+        new Error("Timed out after " + timeout + "ms waiting for chromedriver to report its port."),
+      );
+    }, timeout);
+    /**
+     * @param {Error | null} err
+     * @param {number} [port]
+     */
+    function finish(err, port) {
+      clearTimeout(timer);
+      cp.stdout.removeListener("data", onData);
+      cp.removeListener("error", finish);
+      cp.removeListener("exit", onExit);
+      if (err) reject(err);
+      else resolve(/** @type {number} */ (port));
+    }
+    function onData(data) {
+      output += data;
+      const match = startedRegexp.exec(output);
+      if (match) finish(null, parseInt(match[1]));
+    }
+    /**
+     * @param {number | null} code
+     */
+    function onExit(code) {
+      finish(new Error("chromedriver exited with code " + code + " before reporting its port."));
+    }
+    cp.stdout.on("data", onData);
+    cp.once("error", finish);
+    cp.once("exit", onExit);
+  });
+}
 process.env.PATH = path.join(__dirname, "chromedriver") + path.delimiter + process.env.PATH;
 const crpath =
   process.platform === "win32"
     ? path.join(__dirname, "chromedriver", "chromedriver.exe")
     : path.join(__dirname, "chromedriver", "chromedriver");
 const version = "151.0.7922.77";
-/** @type {import("node:child_process").ChildProcessWithoutNullStreams | null} */
+/**
+ * A chromedriver child process. `port` is the port it listens on, and is only
+ * set once known: immediately for an explicit port, and when the returned
+ * promise resolves for `--port=0`.
+ * @typedef {import("node:child_process").ChildProcessWithoutNullStreams & { port?: number }} ChromedriverProcess
+ */
+/** @type {ChromedriverProcess | null} */
 let defaultInstance = null;
 
 function start(args, returnPromise) {
@@ -45,18 +96,23 @@ function start(args, returnPromise) {
     args.push("--port=9515");
     port = 9515;
   }
+  /** @type {ChromedriverProcess} */
   const cp = require("child_process").spawn(command, args);
   cp.stdout.pipe(process.stdout);
   cp.stderr.pipe(process.stderr);
+  if (port !== 0) cp.port = port;
   defaultInstance = cp;
   if (!returnPromise) return cp;
-  // with --port=0 the OS assigns a random port we cannot know here, so there is
-  // nothing to poll; resolve as soon as the process is spawned.
-  if (port === 0) return Promise.resolve(cp);
   const pollInterval = 100;
   const timeout = 10000;
-  return tcpPortUsed.waitUntilUsed(port, pollInterval, timeout).then(function () {
-    return cp;
+  // `--port=0` asks the OS for a free port, so which port to poll is only known
+  // once chromedriver reports it on stdout.
+  const portPromise = port === 0 ? getPortFromStdout(cp, timeout) : Promise.resolve(port);
+  return portPromise.then(function (listeningPort) {
+    cp.port = listeningPort;
+    return tcpPortUsed.waitUntilUsed(listeningPort, pollInterval, timeout).then(function () {
+      return cp;
+    });
   });
 }
 

--- a/tests/start.test.js
+++ b/tests/start.test.js
@@ -1,0 +1,47 @@
+const child_process = require("node:child_process");
+
+describe("start", () => {
+  /** @type {import('child_process').ChildProcess} */
+  let fakeCp;
+  let spawnSpy;
+  beforeEach(() => {
+    fakeCp = /** @type {any} */ ({
+      stdout: { pipe: jest.fn() },
+      stderr: { pipe: jest.fn() },
+      kill: jest.fn(),
+    });
+    jest.resetModules();
+    spawnSpy = jest.spyOn(child_process, "spawn").mockClear().mockReturnValue(fakeCp);
+  });
+  afterAll(() => jest.restoreAllMocks());
+
+  it("uses the default port when none is passed", () => {
+    const { start } = require("../lib/chromedriver");
+    const args = [];
+    start(args);
+    expect(args).toContain("--port=9515");
+    expect(spawnSpy.mock.calls[0][1]).toContain("--port=9515");
+  });
+
+  it("keeps --port=0 instead of overriding it with the default", () => {
+    const { start } = require("../lib/chromedriver");
+    const args = ["--port=0"];
+    start(args);
+    expect(args).not.toContain("--port=9515");
+    expect(spawnSpy.mock.calls[0][1]).toEqual(["--port=0"]);
+  });
+
+  it("resolves immediately for --port=0 when a promise is requested", async () => {
+    const { start } = require("../lib/chromedriver");
+    const cp = await start(["--port=0"], true);
+    expect(cp).toBe(fakeCp);
+  });
+
+  it("keeps an explicit port", () => {
+    const { start } = require("../lib/chromedriver");
+    const args = ["--port=9222"];
+    start(args);
+    expect(args).not.toContain("--port=9515");
+    expect(spawnSpy.mock.calls[0][1]).toEqual(["--port=9222"]);
+  });
+});

--- a/tests/start.test.js
+++ b/tests/start.test.js
@@ -1,47 +1,146 @@
 const child_process = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+jest.mock("tcp-port-used", () => ({ waitUntilUsed: jest.fn(() => Promise.resolve()) }));
+
+const startedLine = "ChromeDriver was started successfully on port 51234.\n";
 
 describe("start", () => {
-  /** @type {import('child_process').ChildProcess} */
+  /** @type {any} */
   let fakeCp;
+  /** @type {jest.SpyInstance} */
   let spawnSpy;
+  // The module keeps state between calls, so it and its mocked dependency are
+  // required per test, after the registry is reset.
+  function load() {
+    return {
+      chromedriver: require("../lib/chromedriver"),
+      tcpPortUsed: require("tcp-port-used"),
+    };
+  }
+  const flush = () => new Promise((resolve) => setImmediate(resolve));
   beforeEach(() => {
-    fakeCp = /** @type {any} */ ({
-      stdout: { pipe: jest.fn() },
-      stderr: { pipe: jest.fn() },
-      kill: jest.fn(),
-    });
+    fakeCp = new EventEmitter();
+    fakeCp.stdout = Object.assign(new EventEmitter(), { pipe: jest.fn() });
+    fakeCp.stderr = Object.assign(new EventEmitter(), { pipe: jest.fn() });
+    fakeCp.kill = jest.fn();
     jest.resetModules();
     spawnSpy = jest.spyOn(child_process, "spawn").mockClear().mockReturnValue(fakeCp);
   });
   afterAll(() => jest.restoreAllMocks());
 
   it("uses the default port when none is passed", () => {
-    const { start } = require("../lib/chromedriver");
+    const { chromedriver } = load();
     const args = [];
-    start(args);
+    chromedriver.start(args);
     expect(args).toContain("--port=9515");
     expect(spawnSpy.mock.calls[0][1]).toContain("--port=9515");
   });
 
   it("keeps --port=0 instead of overriding it with the default", () => {
-    const { start } = require("../lib/chromedriver");
+    const { chromedriver } = load();
     const args = ["--port=0"];
-    start(args);
+    chromedriver.start(args);
     expect(args).not.toContain("--port=9515");
     expect(spawnSpy.mock.calls[0][1]).toEqual(["--port=0"]);
   });
 
-  it("resolves immediately for --port=0 when a promise is requested", async () => {
-    const { start } = require("../lib/chromedriver");
-    const cp = await start(["--port=0"], true);
-    expect(cp).toBe(fakeCp);
-  });
-
   it("keeps an explicit port", () => {
-    const { start } = require("../lib/chromedriver");
+    const { chromedriver } = load();
     const args = ["--port=9222"];
-    start(args);
+    chromedriver.start(args);
     expect(args).not.toContain("--port=9515");
     expect(spawnSpy.mock.calls[0][1]).toEqual(["--port=9222"]);
+  });
+
+  it("polls the explicit port and exposes it", async () => {
+    const { chromedriver, tcpPortUsed } = load();
+    const cp = await chromedriver.start(["--port=9222"], true);
+    expect(tcpPortUsed.waitUntilUsed).toHaveBeenCalledWith(9222, 100, 10000);
+    expect(cp).toBe(fakeCp);
+    expect(cp.port).toBe(9222);
+  });
+
+  it("polls the port chromedriver reports for --port=0", async () => {
+    const { chromedriver, tcpPortUsed } = load();
+    const promise = chromedriver.start(["--port=0"], true);
+    fakeCp.stdout.emit("data", startedLine);
+    const cp = await promise;
+    expect(tcpPortUsed.waitUntilUsed).toHaveBeenCalledWith(51234, 100, 10000);
+    expect(cp).toBe(fakeCp);
+    expect(cp.port).toBe(51234);
+  });
+
+  it("does not resolve for --port=0 before the startup line arrives", async () => {
+    const { chromedriver, tcpPortUsed } = load();
+    let resolved = false;
+    const promise = Promise.resolve(chromedriver.start(["--port=0"], true)).then(
+      () => (resolved = true),
+    );
+    // The banner also mentions the requested port and must not be mistaken for
+    // the startup line.
+    fakeCp.stdout.emit("data", "Starting ChromeDriver 151.0.7922.77 on port 0\n");
+    await flush();
+    expect(resolved).toBe(false);
+    expect(tcpPortUsed.waitUntilUsed).not.toHaveBeenCalled();
+    fakeCp.stdout.emit("data", startedLine);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it("reads the startup line when it is split across chunks", async () => {
+    const { chromedriver, tcpPortUsed } = load();
+    const promise = chromedriver.start(["--port=0"], true);
+    fakeCp.stdout.emit("data", "ChromeDriver was started su");
+    fakeCp.stdout.emit("data", "ccessfully on port 51234.\n");
+    await promise;
+    expect(tcpPortUsed.waitUntilUsed).toHaveBeenCalledWith(51234, 100, 10000);
+  });
+
+  it("rejects for --port=0 when the process fails to spawn", async () => {
+    const { chromedriver } = load();
+    const promise = chromedriver.start(["--port=0"], true);
+    fakeCp.emit("error", new Error("spawn chromedriver ENOENT"));
+    await expect(promise).rejects.toThrow("spawn chromedriver ENOENT");
+  });
+
+  it("rejects for --port=0 when the process exits before reporting its port", async () => {
+    const { chromedriver } = load();
+    const promise = chromedriver.start(["--port=0"], true);
+    fakeCp.emit("exit", 1);
+    await expect(promise).rejects.toThrow("chromedriver exited with code 1");
+  });
+
+  it("rejects for --port=0 when the port is never reported", async () => {
+    const { chromedriver } = load();
+    /** @type {any} */
+    let onTimeout;
+    // The timer callback is swapped in by hand rather than with
+    // jest.useFakeTimers(), which leaves the global timers undefined for the
+    // tests that follow.
+    const realSetTimeout = global.setTimeout;
+    global.setTimeout = /** @type {any} */ (
+      (fn, ms) => {
+        expect(ms).toBe(10000);
+        onTimeout = fn;
+        return 0;
+      }
+    );
+    const promise = chromedriver.start(["--port=0"], true);
+    global.setTimeout = realSetTimeout;
+    const rejection = expect(promise).rejects.toThrow("Timed out after 10000ms");
+    onTimeout();
+    await rejection;
+  });
+
+  it("stops listening to stdout once the port is known", async () => {
+    const { chromedriver } = load();
+    const promise = chromedriver.start(["--port=0"], true);
+    expect(fakeCp.stdout.listenerCount("data")).toBe(1);
+    fakeCp.stdout.emit("data", startedLine);
+    await promise;
+    expect(fakeCp.stdout.listenerCount("data")).toBe(0);
+    expect(fakeCp.listenerCount("error")).toBe(0);
+    expect(fakeCp.listenerCount("exit")).toBe(0);
   });
 });


### PR DESCRIPTION
passing `--port=0` to `start()` is silently ignored.

`getPortFromArgs` returns the number `0`, and the `if (!port)` check treats `0` as falsy, so it overrides the user's request with `--port=9515`. `--port=0` is a valid way to ask the os for a free ephemeral port, which is useful to avoid the fixed 9515 collision when running parallel instances on ci.

changes:
- check `port === undefined` instead of `!port`, so only a missing port triggers the default.
- in the promise path, resolve immediately when `port === 0`. the os picks a random port we can't know here, so `tcpPortUsed.waitUntilUsed(0, ...)` would just time out and reject.

added tests for the default port, `--port=0`, and an explicit port. `npm test`, lint and typecheck pass.
